### PR TITLE
build(CI): test CI on "only" protection in tests

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
-describe('AppController', () => {
+describe.only('AppController', () => {
   let appController: AppController;
 
   beforeEach(async () => {


### PR DESCRIPTION
### Описание изменений
Данный PR демонстриует работоспособность защиты от использования ```only``` в тестах (реализовано на уровне линтера).

